### PR TITLE
chore: update `@achrinza/strong-type` dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/node-ipc/vanilla-test.git"
   },
   "dependencies": {
-    "@achrinza/strong-type": "1.1.1",
+    "@achrinza/strong-type": "1.1.2",
     "ansi-colors-es6": "5.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@achrinza/strong-type@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@achrinza/strong-type@npm:1.1.1"
-  checksum: 82ee7b2fe2278dab447a07cc48d966505d26d1db69dff5c022ecbea4ac1d40a9c4a477e07c8f2b7692c0a5f5d4d045005f118d9c1539fa9f863408f215730289
+"@achrinza/strong-type@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@achrinza/strong-type@npm:1.1.2"
+  checksum: ca11af020eca4ae36d0629cc5d59ba2c8d1c33f4212c6ee44346e3652ebe6a12be12ac0f800e849a80c7556fc1e5e145ce3bd703b1e6b1a313b094796e6c7c77
   languageName: node
   linkType: hard
 
@@ -16,7 +16,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@node-ipc/vanilla-test@workspace:."
   dependencies:
-    "@achrinza/strong-type": 1.1.1
+    "@achrinza/strong-type": 1.1.2
     ansi-colors-es6: 5.0.0
     copyfiles: ^2.4.1
     node-http-server: 8.1.3


### PR DESCRIPTION
Update the dep to bring forward explicit Node.js v18 support.

see: https://github.com/achrinza/event-pubsub/pull/9

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>