### PR TITLE
chore(deps): update `@achrinza/strong-type` dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/node-ipc/vanilla-test.git"
   },
   "dependencies": {
-    "@achrinza/strong-type": "1.1.2",
+    "@achrinza/strong-type": "1.1.3",
     "ansi-colors-es6": "5.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@achrinza/strong-type@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@achrinza/strong-type@npm:1.1.2"
-  checksum: ca11af020eca4ae36d0629cc5d59ba2c8d1c33f4212c6ee44346e3652ebe6a12be12ac0f800e849a80c7556fc1e5e145ce3bd703b1e6b1a313b094796e6c7c77
+"@achrinza/strong-type@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@achrinza/strong-type@npm:1.1.3"
+  checksum: 2c05fe2b9fc262cfae69b4067e3d95cf4e4b93029e7736f54f66b60ac77b17350fb7d101497ed66afdddffe1fc8f2b405c7e7250c11911293a4aa82edbb8e8ab
   languageName: node
   linkType: hard
 
@@ -16,7 +16,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@node-ipc/vanilla-test@workspace:."
   dependencies:
-    "@achrinza/strong-type": 1.1.2
+    "@achrinza/strong-type": 1.1.3
     ansi-colors-es6: 5.0.0
     copyfiles: ^2.4.1
     node-http-server: 8.1.3


### PR DESCRIPTION
Update to `@achrinza/strong-type@1.1.3` for Node.js v19 engine support

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>