### PR TITLE
chore: support Node.js v22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13
           - windows-latest
         node-version:
           - 12

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,8 @@ jobs:
           - 18
           - 19
           - 20
-          - 21 
+          - 21
+          - 22
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/node-ipc/vanilla-test.git"
   },
   "dependencies": {
-    "@achrinza/strong-type": "1.1.7",
+    "@achrinza/strong-type": "1.1.9",
     "ansi-colors-es6": "5.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@achrinza/strong-type@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@achrinza/strong-type@npm:1.1.7"
-  checksum: b72ed20d9e832598ebf2f0b98b1669ddd2bbb8a748ec6f5d9c0599008de49aa4a7efb5764f656e7f090900f443d18065b35e337d19fb626aafe5d94a598c9562
+"@achrinza/strong-type@npm:1.1.9":
+  version: 1.1.9
+  resolution: "@achrinza/strong-type@npm:1.1.9"
+  checksum: ce357b3bcc0eaea8445ddb8de0a9626f80c982318c36316f6201d283974e395929557552ecb5fb502bdf2e09e581dff28a6e97df2ac1a8c4efb66c51c482a6fb
   languageName: node
   linkType: hard
 
@@ -16,7 +16,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@node-ipc/vanilla-test@workspace:."
   dependencies:
-    "@achrinza/strong-type": 1.1.7
+    "@achrinza/strong-type": 1.1.9
     ansi-colors-es6: 5.0.0
     copyfiles: ^2.4.1
     node-http-server: 8.1.3
@@ -130,9 +130,9 @@ __metadata:
   linkType: hard
 
 "escalade@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "escalade@npm:3.1.1"
-  checksum: a3e2a99f07acb74b3ad4989c48ca0c3140f69f923e56d0cba0526240ee470b91010f9d39001f2a4a313841d237ede70a729e92125191ba5d21e74b106800b133
+  version: 3.1.2
+  resolution: "escalade@npm:3.1.2"
+  checksum: 1ec0977aa2772075493002bdbd549d595ff6e9393b1cb0d7d6fcaf78c750da0c158f180938365486f75cb69fba20294351caddfce1b46552a7b6c3cde52eaa02
   languageName: node
   linkType: hard
 
@@ -151,16 +151,16 @@ __metadata:
   linkType: hard
 
 "glob@npm:^7.0.5":
-  version: 7.2.0
-  resolution: "glob@npm:7.2.0"
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
   dependencies:
     fs.realpath: ^1.0.0
     inflight: ^1.0.4
     inherits: 2
-    minimatch: ^3.0.4
+    minimatch: ^3.1.1
     once: ^1.3.0
     path-is-absolute: ^1.0.0
-  checksum: 78a8ea942331f08ed2e055cb5b9e40fe6f46f579d7fd3d694f3412fe5db23223d29b7fee1575440202e9a7ff9a72ab106a39fee39934c7bedafe5e5f8ae20134
+  checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
   languageName: node
   linkType: hard
 
@@ -202,7 +202,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.3, minimatch@npm:^3.0.4":
+"minimatch@npm:^3.0.3, minimatch@npm:^3.1.1":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -275,8 +275,8 @@ __metadata:
   linkType: hard
 
 "readable-stream@npm:~2.3.6":
-  version: 2.3.7
-  resolution: "readable-stream@npm:2.3.7"
+  version: 2.3.8
+  resolution: "readable-stream@npm:2.3.8"
   dependencies:
     core-util-is: ~1.0.0
     inherits: ~2.0.3
@@ -285,7 +285,7 @@ __metadata:
     safe-buffer: ~5.1.1
     string_decoder: ~1.1.1
     util-deprecate: ~1.0.1
-  checksum: e4920cf7549a60f8aaf694d483a0e61b2a878b969d224f89b3bc788b8d920075132c4b55a7494ee944c7b6a9a0eada28a7f6220d80b0312ece70bbf08eeca755
+  checksum: 65645467038704f0c8aaf026a72fbb588a9e2ef7a75cd57a01702ee9db1c4a1e4b03aaad36861a6a0926546a74d174149c8c207527963e0c2d3eee2f37678a42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Dependency update for `@achrinza/strong-type`
- Fixed macOS runner Node.js issue due to migration of `macos-latest` to ARM architecture.